### PR TITLE
Check for `Autograding Tests` not `Autograding`

### DIFF
--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -41,11 +41,11 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   const checkRunsResponse = await octokit.rest.checks.listForRepo({
     owner,
     repo,
-    check_name: 'Autograding'
+    check_name: 'Autograding Tests'
   })
 
-  // Filter to find the check run named "Autograding" for the specific workflow run ID
-  const checkRun = checkRunsResponse.data.check_runs.find(cr => cr.name === 'Autograding' && cr.check_suite.workflow_run_id === runId)
+  // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
+  const checkRun = checkRunsResponse.data.check_runs.find(cr => cr.name === 'Autograding Tests' && cr.check_suite.workflow_run_id === runId)
 
   if (!checkRun) return
 


### PR DESCRIPTION
This pull request mainly focuses on refining the autograding test process in the `src/notify-classroom.js` file. The key change is the renaming of the check run from "Autograding" to "Autograding Tests", which is reflected in both the request to list check runs for the repo and the filter function used to find the specific check run.

Changes to autograding test process:

* <a href="diffhunk://#diff-7f1258c823fc6a97c7ae93eaa3419c6fe5f80d03615e46435e1b01dd0aa71c55L44-R48">`src/notify-classroom.js`</a>: Renamed the check run from "Autograding" to "Autograding Tests" in the request to list check runs for the repo and in the filter function used to find the specific check run.