### PR TITLE
Fix Notify Classroom File

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ permissions:
   actions: read
   contents: read
 jobs:
-  integration:
+  autograding:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# For more information, see [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)
+
+# This repository is maintained by:
+* @education/classroom-reviewers

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -42,9 +42,6 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   if (Number.isNaN(runId)) return
 
   // Fetch the workflow run
-  console.log(`Check owner: ${owner}`)
-  console.log(`Check repo: ${repo}`)
-  console.log(`Check runId: ${runId}`)
   const workflowRunResponse = await octokit.rest.actions.getWorkflowRun({
     owner,
     repo,
@@ -59,18 +56,11 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
     repo,
-    check_name: 'integration',
+    check_name: 'autograding',
     check_suite_id: checkSuiteId,
   })
 
   console.log(`Check checkRunsResponse: ${checkRunsResponse.data.total_count}`)
-
-  // List check runs for the repository
-  // const checkRunsResponse = await octokit.rest.checks.listForRef({
-  //   owner,
-  //   repo,
-  //   check_name: 'Autograding Tests'
-  // })
 
   // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
   const checkRun = checkRunsResponse.data.total_count === 1 && checkRunsResponse.data.check_runs[0]

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -14,7 +14,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
 
     return acc
   }, { totalScore: 0, maxScore: 0 })
-  console.log(`Total points: ${totalScore}/${maxScore}`)
+  
   if (!maxScore) return
 
   // Our action will need to API access the repository so we require a token
@@ -48,11 +48,9 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
     run_id: runId,
   })
 
-  console.log(`Check workflowRunResponse: ${workflowRunResponse.data.check_suite_url}`)
   // Find the check suite run
   const checkSuiteUrl = workflowRunResponse.data.check_suite_url
   const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10)
-  console.log(`Check checkSuiteId: ${checkSuiteId}`)
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
     repo,
@@ -60,11 +58,8 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
     check_suite_id: checkSuiteId,
   })
 
-  console.log(`Check checkRunsResponse: ${checkRunsResponse.data.total_count}`)
-
   // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
   const checkRun = checkRunsResponse.data.total_count === 1 && checkRunsResponse.data.check_runs[0]
-  console.log(`Check run: ${checkRun}`)
   if (!checkRun) return
 
   // Update the checkrun, we'll assign the title, summary and text even though we expect

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -14,15 +14,18 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
 
     return acc
   }, { totalScore: 0, maxScore: 0 })
+  console.log(`Total points: ${totalScore}/${maxScore}`)
   if (!maxScore) return
 
   // Our action will need to API access the repository so we require a token
   // This will need to be set in the calling workflow, otherwise we'll exit
   const token = process.env.GITHUB_TOKEN || core.getInput('token')
+  console.log(`Token: ${token}`)
   if (!token || token === '') return
 
   // Create the octokit client
   const octokit = github.getOctokit(token)
+  console.log(`Octokit: ${octokit}`)
   if (!octokit) return
 
   // The environment contains a variable for current repository. The repository
@@ -35,6 +38,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
 
   // We need the workflow run id
   const runId = parseInt(process.env.GITHUB_RUN_ID || '')
+  console.log(`Run ID: ${runId}`)
   if (Number.isNaN(runId)) return
 
   // List check runs for the repository
@@ -46,7 +50,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
 
   // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
   const checkRun = checkRunsResponse.data.check_runs.find(cr => cr.name === 'Autograding Tests' && cr.check_suite.workflow_run_id === runId)
-
+  console.log(`Check run: ${checkRun}`)
   if (!checkRun) return
 
   // Update the checkrun, we'll assign the title, summary and text even though we expect

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -58,7 +58,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
     check_suite_id: checkSuiteId,
   })
 
-  console.log(`Check checkRunsResponse: ${checkRunsResponse}`)
+  console.log(`Check checkRunsResponse: ${checkRunsResponse.data.total_count}`)
 
   // List check runs for the repository
   // const checkRunsResponse = await octokit.rest.checks.listForRef({

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -49,8 +49,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   })
 
   // Find the check suite run
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const checkSuiteUrl = (workflowRunResponse.data).check_suite_url
+  const checkSuiteUrl = workflowRunResponse.data.check_suite_url
   const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10)
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
@@ -58,6 +57,8 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
     check_name: 'Autograding Tests',
     check_suite_id: checkSuiteId,
   })
+
+  console.log(`Check checkRunsResponse: ${checkRunsResponse}`)
 
   // List check runs for the repository
   // const checkRunsResponse = await octokit.rest.checks.listForRef({

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -51,10 +51,11 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
     run_id: runId,
   })
 
-  console.log(`Check workflowRunResponse: ${workflowRunResponse.data}`)
+  console.log(`Check workflowRunResponse: ${workflowRunResponse.data.check_suite_url}`)
   // Find the check suite run
   const checkSuiteUrl = workflowRunResponse.data.check_suite_url
   const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10)
+  console.log(`Check checkSuiteId: ${checkSuiteId}`)
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
     repo,

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -20,12 +20,10 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   // Our action will need to API access the repository so we require a token
   // This will need to be set in the calling workflow, otherwise we'll exit
   const token = process.env.GITHUB_TOKEN || core.getInput('token')
-  console.log(`Token: ${token}`)
   if (!token || token === '') return
 
   // Create the octokit client
   const octokit = github.getOctokit(token)
-  console.log(`Octokit: ${octokit}`)
   if (!octokit) return
 
   // The environment contains a variable for current repository. The repository
@@ -38,7 +36,6 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
 
   // We need the workflow run id
   const runId = parseInt(process.env.GITHUB_RUN_ID || '')
-  console.log(`Run ID: ${runId}`)
   if (Number.isNaN(runId)) return
 
   // Fetch the workflow run

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -42,12 +42,16 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   if (Number.isNaN(runId)) return
 
   // Fetch the workflow run
+  console.log(`Check owner: ${owner}`)
+  console.log(`Check repo: ${repo}`)
+  console.log(`Check runId: ${runId}`)
   const workflowRunResponse = await octokit.rest.actions.getWorkflowRun({
     owner,
     repo,
     run_id: runId,
   })
 
+  console.log(`Check workflowRunResponse: ${workflowRunResponse.data}`)
   // Find the check suite run
   const checkSuiteUrl = workflowRunResponse.data.check_suite_url
   const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10)

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -42,7 +42,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   if (Number.isNaN(runId)) return
 
   // List check runs for the repository
-  const checkRunsResponse = await octokit.rest.checks.listForRepo({
+  const checkRunsResponse = await octokit.rest.checks.listForRef({
     owner,
     repo,
     check_name: 'Autograding Tests'

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -59,7 +59,7 @@ exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
     repo,
-    check_name: 'Autograding Tests',
+    check_name: 'integration',
     check_suite_id: checkSuiteId,
   })
 


### PR DESCRIPTION
This pull request primarily updates the `NotifyClassroom` function in the `src/notify-classroom.js` file and renames `integration -> autograding` for the job name in the `.github/workflows/integration.yml` file since that's what we look for in the code. The changes in the `NotifyClassroom` function include modifying how the function fetches and filters check runs.

Changes to `NotifyClassroom` function:

* <a href="diffhunk://#diff-7f1258c823fc6a97c7ae93eaa3419c6fe5f80d03615e46435e1b01dd0aa71c55R17-R28">`src/notify-classroom.js`</a>: Added console logs to print the token, octokit client, and run ID for debugging purposes.
* <a href="diffhunk://#diff-7f1258c823fc6a97c7ae93eaa3419c6fe5f80d03615e46435e1b01dd0aa71c55R41-R62">`src/notify-classroom.js`</a>: Modified the function to fetch the workflow run instead of listing check runs for the repository, and changed the check run filter to find the check run named "Autograding Tests" for the specific workflow run ID.

Changes to workflow:

* <a href="diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL10-R10">`.github/workflows/integration.yml`</a>: Changed the job name from `integration` to `autograding`.