### PR TITLE
Modify notifyClassroom to have correct autograding tests

### DIFF
--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -1,92 +1,96 @@
-const core = require('@actions/core')
-const github = require('@actions/github')
+const core = require("@actions/core");
+const github = require("@actions/github");
 
-exports.NotifyClassroom = async function NotifyClassroom (runnerResults) {
+exports.NotifyClassroom = async function NotifyClassroom(runnerResults) {
   // combine max score and total score from each {runner, results} pair
   // if max_score is greater than 0 run the rest of this code
-  const { totalScore, maxScore } = runnerResults.reduce((acc, { results }) => {
-    if (!results.max_score) return acc
+  const { totalPoints, maxPoints } = runnerResults.reduce(
+    (acc, { results }) => {
+      if (!results.max_score) return acc;
 
-    acc.maxScore += results.max_score
-    results.tests.forEach(({ score }) => {
-      acc.totalScore += score
-    })
+      acc.maxPoints += results.max_score;
+      results.tests.forEach(({ score }) => {
+        acc.totalPoints += score;
+      });
 
-    return acc
-  }, { totalScore: 0, maxScore: 0 })
-  console.log(`max score: ${maxScore}`)
-  if (!maxScore) return
+      return acc;
+    },
+    { totalPoints: 0, maxPoints: 0 }
+  );
+  console.log(`max score: ${maxPoints}`);
+  if (!maxPoints) return;
 
   // Our action will need to API access the repository so we require a token
   // This will need to be set in the calling workflow, otherwise we'll exit
-  const token = process.env.GITHUB_TOKEN || core.getInput('token')
-  console.log(`Token: ${token}`)
-  if (!token || token === '') return
+  const token = process.env.GITHUB_TOKEN || core.getInput("token");
+  console.log(`Token: ${token}`);
+  if (!token || token === "") return;
 
   // Create the octokit client
-  const octokit = github.getOctokit(token)
-  console.log(`Octokit: ${octokit}`)
-  if (!octokit) return
+  const octokit = github.getOctokit(token);
+  console.log(`Octokit: ${octokit}`);
+  if (!octokit) return;
 
   // The environment contains a variable for current repository. The repository
   // will be formatted as a name with owner (`nwo`); e.g., jeffrafter/example
   // We'll split this into two separate variables for later use
-  const nwo = process.env.GITHUB_REPOSITORY || '/'
-  const [owner, repo] = nwo.split('/')
-  if (!owner) return
-  if (!repo) return
+  const nwo = process.env.GITHUB_REPOSITORY || "/";
+  const [owner, repo] = nwo.split("/");
+  if (!owner) return;
+  if (!repo) return;
 
   // We need the workflow run id
-  const runId = parseInt(process.env.GITHUB_RUN_ID || '')
-  console.log(`Run ID: ${runId}`)
-  if (Number.isNaN(runId)) return
+  const runId = parseInt(process.env.GITHUB_RUN_ID || "");
+  console.log(`Run ID: ${runId}`);
+  if (Number.isNaN(runId)) return;
 
   // Fetch the workflow run
   const workflowRunResponse = await octokit.rest.actions.getWorkflowRun({
     owner,
     repo,
     run_id: runId,
-  })
+  });
 
   // Find the check suite run
-  console.log(`Workflow Run Response: ${workflowRunResponse.data.check_suite_url}`)
-  const checkSuiteUrl = workflowRunResponse.data.check_suite_url
-  const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10)
+  console.log(`Workflow Run Response: ${workflowRunResponse.data.check_suite_url}`);
+  const checkSuiteUrl = workflowRunResponse.data.check_suite_url;
+  const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10);
+
   const checkRunsResponse = await octokit.rest.checks.listForSuite({
     owner,
     repo,
-    check_name: 'run-tests',
+    check_name: "run-autograding-tests",
     check_suite_id: checkSuiteId,
-  })
-
-  console.log(`Check Runs Response: ${checkRunsResponse.data}`)
+  });
 
   // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
-  const checkRun = checkRunsResponse.data.total_count === 1 && checkRunsResponse.data.check_runs[0]
-  console.log(`Check Run: ${checkRun}`)
-  if (!checkRun) return
+  const checkRun = checkRunsResponse.data.total_count === 1 && checkRunsResponse.data.check_runs[0];
+
+  if (!checkRun) return;
 
   // Update the checkrun, we'll assign the title, summary and text even though we expect
   // the title and summary to be overwritten by GitHub Actions (they are required in this call)
   // We'll also store the total in an annotation to future-proof
-  const text = `Points ${totalScore}/${maxScore}`
+  const text = `Points ${totalPoints}/${maxPoints}`;
   await octokit.rest.checks.update({
     owner,
     repo,
     check_run_id: checkRun.id,
     output: {
-      title: 'Autograding',
+      title: "Autograding",
       summary: text,
-      text,
-      annotations: [{
-        // Using the `.github` path is what GitHub Actions does
-        path: '.github',
-        start_line: 1,
-        end_line: 1,
-        annotation_level: 'notice',
-        message: text,
-        title: 'Autograding complete'
-      }]
-    }
-  })
-}
+      text: JSON.stringify({ totalPoints, maxPoints }),
+      annotations: [
+        {
+          // Using the `.github` path is what GitHub Actions does
+          path: ".github",
+          start_line: 1,
+          end_line: 1,
+          annotation_level: "notice",
+          message: text,
+          title: "Autograding complete",
+        },
+      ],
+    },
+  });
+};


### PR DESCRIPTION
This PR changes the `check_name` to match the autograding workflow file that is generated on the classroom side. This essentially won't matter too much as we have changed the Classroom webhook event handler to find by the head sha, which will be more secure and more robust for teachers to create their own workflow and not have to use the "run-autograding-tests" check name.

In addition, because the `output.summary` and `output.text` are being written as the same things, we changed it so `output.text` is a JSON string which we will parse on the Classroom side of things and make it easier. 

Again, so if teachers _want_ to modify/create their own reporter, they don't need to use the exact regex we have been looking for (ie. "Points x/x). This will make things more flexible and easier to understand on this side of things, since our API is not open source.