### PR TITLE
Add Python Runner to Integration Job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,13 +37,13 @@ jobs:
           timeout: 10
           max-score: 20
       - name: A Python test
-        id: python-runner
+        id: python-test
         uses: education/autograding-python-grader@main
       - name: Autograding Reporter
         uses: ./
         env:
           SHOUT-TEST_RESULTS: "${{steps.shout-test.outputs.result}}"
           A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
-          A-PYTHON-TEST_RESULTS: "${{steps.python-runner.outputs.result}}"
+          A-PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
         with:
           runners: shout-test,a-command-test,python-runner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,14 +36,13 @@ jobs:
           command: rspec hello_spec.rb
           timeout: 10
           max-score: 20
-      - name: A Python test
+      - uses: education/autograding-python-grader@main
         id: python-test
-        uses: education/autograding-python-grader@main
       - name: Autograding Reporter
         uses: ./
         env:
           SHOUT-TEST_RESULTS: "${{steps.shout-test.outputs.result}}"
           A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
-          A-PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
+          PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
         with:
           runners: shout-test,a-command-test,python-test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
         id: python-test
         uses: education/autograding-python-grader@main
         with:
-          test-name: Python test
+          max-score: 30
       - name: Autograding Reporter
         uses: ./
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,5 +50,6 @@ jobs:
           SHOUT-TEST_RESULTS: "${{steps.shout-test.outputs.result}}"
           A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
           PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
+          PYTHON-TEST-WITH-SCORE_RESULTS: "${{steps.python-test-with-score.outputs.result}}"
         with:
           runners: shout-test,a-command-test,python-test,python-test-with-score

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,13 @@
-name: Test
-on: 
-- push
-- workflow_dispatch
+name: Autograding Tests
+"on":
+  - push
+  - workflow_dispatch
+permissions:
+  checks: write
+  actions: read
+  contents: read
 jobs:
-  integration:
+  autograding:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -11,14 +15,35 @@ jobs:
         run: |
           npm install --silent
           npm run build
-      - uses: education/autograding-python-grader@main
-        id: runner1
-      - uses: education/autograding-python-grader@main
-        id: runner2
-      - name: Show Output
+      - uses: ruby/setup-ruby@v1
+      - name: Shout Test
+        id: shout-test
+        uses: education/autograding-io-grader@v1
+        with:
+          test-name: Shout Test
+          command: "./test/bin/shout.sh"
+          input: hello
+          expected-output: HELLO
+          comparison-method: exact
+          timeout: 10
+          max-score: 10
+      - name: A command test
+        id: a-command-test
+        uses: education/autograding-command-grader@v1
+        with:
+          test-name: A command test
+          setup-command: bundle install
+          command: rspec hello_spec.rb
+          timeout: 10
+          max-score: 20
+      - name: A Python test
+        id: python-runner
+        uses: education/autograding-python-grader@main
+      - name: Autograding Reporter
         uses: ./
         env:
-          RUNNER1_RESULTS: ${{steps.runner1.outputs.result}}
-          RUNNER2_RESULTS: ${{steps.runner2.outputs.result}}
+          SHOUT-TEST_RESULTS: "${{steps.shout-test.outputs.result}}"
+          A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
+          A-PYTHON-TEST_RESULTS: "${{steps.python-runner.outputs.result}}"
         with:
-          runners: "runner1,runner2"
+          runners: shout-test,a-command-test,python-runner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Python test
         id: python-test
         uses: education/autograding-python-grader@add-max-score
+      - name: Python test with score
+        id: python-test-with-score
+        uses: education/autograding-python-grader@add-max-score
+        with:
+          max-score: 30
       - name: Autograding Reporter
         uses: ./
         env:
@@ -46,4 +51,4 @@ jobs:
           A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
           PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
         with:
-          runners: shout-test,a-command-test,python-test
+          runners: shout-test,a-command-test,python-test,python-test-with-score

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Python test
         id: python-test
         uses: education/autograding-python-grader@add-max-score
-        with:
-          max-score: 30
       - name: Autograding Reporter
         uses: ./
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,45 +1,18 @@
-name: Autograding Tests
-"on":
-  - push
-  - workflow_dispatch
-permissions:
-  checks: write
-  actions: read
-  contents: read
+name: Test
+on: [push]
 jobs:
-  autograding:
+  integration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install and build node assets
-        run: |
-          npm install --silent
-          npm run build
-      - uses: ruby/setup-ruby@v1
-      - name: Shout Test
-        id: shout-test
-        uses: education/autograding-io-grader@v1
-        with:
-          test-name: Shout Test
-          command: "./test/bin/shout.sh"
-          input: hello
-          expected-output: HELLO
-          comparison-method: exact
-          timeout: 10
-          max-score: 100
-      - name: A command test
-        id: a-command-test
-        uses: education/autograding-command-grader@v1
-        with:
-          test-name: A command test
-          setup-command: bundle install
-          command: rspec hello_spec.rb
-          timeout: 10
-          max-score: 100
-      - name: Autograding Reporter
+      - uses: octosteve/python-test-runner@add-additional-info
+        id: runner1
+      - uses: octosteve/python-test-runner@add-additional-info
+        id: runner2
+      - name: Show Output
         uses: ./
         env:
-          SHOUT-TEST_RESULTS: "${{steps.shout-test.outputs.result}}"
-          A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
+          RUNNER1_RESULTS: ${{steps.runner1.outputs.result}}
+          RUNNER2_RESULTS: ${{steps.runner2.outputs.result}}
         with:
-          runners: shout-test,a-command-test
+          runners: "runner1,runner2"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install and build node assets
+        run: |
+          npm install --silent
+          npm run build
       - uses: octosteve/python-test-runner@add-additional-info
         id: runner1
       - uses: octosteve/python-test-runner@add-additional-info

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,9 +9,9 @@ jobs:
         run: |
           npm install --silent
           npm run build
-      - uses: octosteve/python-test-runner@add-additional-info
+      - uses: education/autograding-python-grader@main
         id: runner1
-      - uses: octosteve/python-test-runner@add-additional-info
+      - uses: education/autograding-python-grader@main
         id: runner2
       - name: Show Output
         uses: ./

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,8 +36,9 @@ jobs:
           command: rspec hello_spec.rb
           timeout: 10
           max-score: 20
-      - uses: education/autograding-python-grader@main
+      - name: Python test
         id: python-test
+        uses: education/autograding-python-grader@main
       - name: Autograding Reporter
         uses: ./
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
           max-score: 20
       - name: Python test
         id: python-test
-        uses: education/autograding-python-grader@main
+        uses: education/autograding-python-grader@add-max-score
         with:
           max-score: 30
       - name: Autograding Reporter

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Python test
         id: python-test
         uses: education/autograding-python-grader@main
+        with:
+          test-name: Python test
       - name: Autograding Reporter
         uses: ./
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,7 @@
 name: Test
-on: [push]
+on: 
+- push
+- workflow_dispatch
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,4 +46,4 @@ jobs:
           A-COMMAND-TEST_RESULTS: "${{steps.a-command-test.outputs.result}}"
           A-PYTHON-TEST_RESULTS: "${{steps.python-test.outputs.result}}"
         with:
-          runners: shout-test,a-command-test,python-runner
+          runners: shout-test,a-command-test,python-test

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,83 +1,103 @@
-const process = require("process");
-const cp = require("child_process");
-const path = require("path");
+const process = require('process')
+const cp = require('child_process')
+const path = require('path')
 
-const node = process.execPath;
-const ip = path.join(__dirname, "..", "src", "main.js");
+const node = process.execPath
+const ip = path.join(__dirname, '..', 'src', 'main.js')
 const options = {
   env: process.env,
-  encoding: "utf-8",
-};
+  encoding: 'utf-8',
+}
 
-const { parseRunnerResults } = require("../src/main");
+const {parseRunnerResults} = require('../src/main')
 
-test("test runs", () => {
-  process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }').toString("base64");
-  process.env.INPUT_RUNNERS = "result1";
+test('test runs', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1'
 
-  const child = cp.spawnSync(node, [ip], options);
-  const stdout = child.stdout.toString();
-  expect(stdout).toContain(`✅ Test 1`);
-});
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  expect(stdout).toContain(`✅ Test 1`)
+})
 
-test("test fails", () => {
-  process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "fail", "message": "Test failed with non-zero exit code." }] }').toString("base64");
-  process.env.INPUT_RUNNERS = "result1";
+test('test fails', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "fail", "message": "Test failed with non-zero exit code." }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1'
 
-  const child = cp.spawnSync(node, [ip], options);
-  const stdout = child.stdout.toString();
-  expect(stdout).toContain(`❌ Test 1`);
-});
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  expect(stdout).toContain(`❌ Test 1`)
+})
 
-test("test errors out", () => {
-  process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "error", "message": "Test failed to execute." }] }').toString("base64");
-  process.env.INPUT_RUNNERS = "result1";
+test('test errors out', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "error", "message": "Test failed to execute." }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1'
 
-  const child = cp.spawnSync(node, [ip], options);
-  const stdout = child.stdout.toString();
-  expect(stdout).toContain(`Error: Test failed to execute.`);
-});
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  expect(stdout).toContain(`Error: Test failed to execute.`)
+})
 
-test("fails to run if input not in the right format", () => {
-  process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }').toString("base64");
-  process.env.RESULT2_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }').toString("base64");
-  process.env.INPUT_RUNNERS = "[result1,result2]";
+test('fails to run if input not in the right format', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = '[result1,result2]'
 
-  const child = cp.spawnSync(node, [ip], options);
-  const stderr = child.stderr.toString();
-  expect(stderr).toContain(`The runners input must be a comma-separated list of strings.`);
-});
+  const child = cp.spawnSync(node, [ip], options)
+  const stderr = child.stderr.toString()
+  expect(stderr).toContain(`The runners input must be a comma-separated list of strings.`)
+})
 
-// test('test runs with multiple runners', () => {
-//   process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }').toString('base64')
-//   process.env.RESULT2_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }').toString('base64')
-//   process.env.INPUT_RUNNERS = 'result1,result2'
+test('test runs with multiple runners', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1,result2'
 
-//   const child = cp.spawnSync(node, [ip], options)
-//   const stdout = child.stdout.toString()
-//   console.log(stdout)
-//   expect(stdout).toBe('pass')
-// })
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  console.log(stdout)
+  expect(stdout).toContain('✅')
+})
 
-// test('test fails with multiple runners', () => {
-//   process.env.RESULT1_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 1", "status": "fail", "message": null }] }').toString('base64')
-//   process.env.RESULT2_RESULTS = Buffer.from('{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }').toString('base64')
-//   process.env.INPUT_RUNNERS = 'result1,result2'
+test('test fails with multiple runners', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "fail", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1,result2'
 
-//   const child = cp.spawnSync(node, [ip], options)
-//   const stdout = child.stdout.toString()
-//   console.log(stdout)
-//   expect(stdout).toBe('fail')
-// })
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  console.log(stdout)
+  expect(stdout).toContain('❌')
+})
 
-test("test autograding-output.parseRunnerResults", function () {
-  process.env.INPUT_RUNNERS = "result1,result2";
+test('test autograding-output.parseRunnerResults', function () {
+  process.env.INPUT_RUNNERS = 'result1,result2'
 
-  let testResults1 = parseRunnerResults(process.env.INPUT_RUNNERS);
-  expect(testResults1.length).toBe(2);
-  expect(testResults1[0].runner).toBe("result1");
-  expect(testResults1[1].runner).toBe("result2");
+  const testResults1 = parseRunnerResults(process.env.INPUT_RUNNERS)
+  expect(testResults1.length).toBe(2)
+  expect(testResults1[0].runner).toBe('result1')
+  expect(testResults1[1].runner).toBe('result2')
 
-  process.env.INPUT_RUNNERS = "[result1,result2]";
-  expect(() => parseRunnerResults(process.env.INPUT_RUNNERS)).toThrow("The runners input must be a comma-separated list of strings.");
-});
+  process.env.INPUT_RUNNERS = '[result1,result2]'
+  expect(() => parseRunnerResults(process.env.INPUT_RUNNERS)).toThrow(
+    'The runners input must be a comma-separated list of strings.',
+  )
+})

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -34,7 +34,7 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
           console.log(`${COLORS.red}❌ ${test.name}\n${COLORS.reset}`)
         }
         if (test.test_code) {
-          console.log(`Test code: ${test.test_code}\n`)
+          console.log(`Test code:\n${test.test_code}\n`)
         }
       })
 

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -17,22 +17,25 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
       }
 
       console.log(`🔄 Processing: ${runner}`)
-      console.log(results)
       let passedTests = 0
       const totalTests = results.tests.length
 
       results.tests.forEach((test) => {
         if (test.status === 'pass') {
-          console.log(`${COLORS.green}✅ ${test.name}${COLORS.reset}`)
           passedTests += 1
+          if (test.line_no) {
+            console.log(`${COLORS.green}✅ ${test.name}:${test.line_no}${COLORS.reset}`)
+          } else {
+            console.log(`${COLORS.green}✅ ${test.name}${COLORS.reset}`)
+          }
+          if (test.test_code) {
+            console.log(`Test code: ${test.test_code}\n`)
+          }
         } else if (test.status === 'error') {
           console.log(`Error: ${test.message || `Failed to run test '${test.name}'`}\n${COLORS.reset}`)
         } else {
           console.log(`${COLORS.red}❌ ${test.name}\n`)
           console.log(`${test.message || ''}\n${COLORS.reset}`)
-        }
-        if (test.test_code) {
-          console.log(`Test code: ${test.test_code}\n`)
         }
       })
 

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -24,14 +24,18 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
         if (test.status === 'pass') {
           passedTests += 1
           if (test.line_no !== 0) {
-            console.log(`${COLORS.green}✅ ${test.name}, line:${test.line_no}${COLORS.reset}`)
+            console.log(`${COLORS.green}✅ ${test.name} - line ${test.line_no}${COLORS.reset}`)
           } else {
             console.log(`${COLORS.green}✅ ${test.name}${COLORS.reset}`)
           }
         } else if (test.status === 'error') {
           console.log(`Error: ${test.message || `Failed to run test '${test.name}'`}\n${COLORS.reset}`)
         } else {
-          console.log(`${COLORS.red}❌ ${test.name}${COLORS.reset}`)
+          if (test.line_no !== 0) {
+            console.log(`${COLORS.red}❌ ${test.name} - line ${test.line_no}${COLORS.reset}`)
+          } else {
+            console.log(`${COLORS.red}❌ ${test.name}${COLORS.reset}`)
+          }
         }
         if (test.test_code) {
           console.log(`Test code:\n${test.test_code}\n`)

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -34,7 +34,7 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
           console.log(`${COLORS.red}❌ ${test.name}${COLORS.reset}`)
         }
         if (test.test_code) {
-          console.log(`Test code:\n${test.test_code}\n\n`)
+          console.log(`Test code:\n${test.test_code}\n`)
         }
       })
 

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -31,10 +31,10 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
         } else if (test.status === 'error') {
           console.log(`Error: ${test.message || `Failed to run test '${test.name}'`}\n${COLORS.reset}`)
         } else {
-          console.log(`${COLORS.red}❌ ${test.name}\n${COLORS.reset}`)
+          console.log(`${COLORS.red}❌ ${test.name}${COLORS.reset}`)
         }
         if (test.test_code) {
-          console.log(`Test code:\n${test.test_code}\n`)
+          console.log(`Test code:\n${test.test_code}\n\n`)
         }
       })
 

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -23,19 +23,18 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
       results.tests.forEach((test) => {
         if (test.status === 'pass') {
           passedTests += 1
-          if (test.line_no) {
-            console.log(`${COLORS.green}✅ ${test.name}:${test.line_no}${COLORS.reset}`)
+          if (test.line_no !== 0) {
+            console.log(`${COLORS.green}✅ ${test.name}, line:${test.line_no}${COLORS.reset}`)
           } else {
             console.log(`${COLORS.green}✅ ${test.name}${COLORS.reset}`)
-          }
-          if (test.test_code) {
-            console.log(`Test code: ${test.test_code}\n`)
           }
         } else if (test.status === 'error') {
           console.log(`Error: ${test.message || `Failed to run test '${test.name}'`}\n${COLORS.reset}`)
         } else {
-          console.log(`${COLORS.red}❌ ${test.name}\n`)
-          console.log(`${test.message || ''}\n${COLORS.reset}`)
+          console.log(`${COLORS.red}❌ ${test.name}\n${COLORS.reset}`)
+        }
+        if (test.test_code) {
+          console.log(`Test code: ${test.test_code}\n`)
         }
       })
 

--- a/src/console-results.js
+++ b/src/console-results.js
@@ -17,6 +17,7 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
       }
 
       console.log(`🔄 Processing: ${runner}`)
+      console.log(results)
       let passedTests = 0
       const totalTests = results.tests.length
 
@@ -29,6 +30,9 @@ exports.ConsoleResults = function ConsoleResults(runnerResults) {
         } else {
           console.log(`${COLORS.red}❌ ${test.name}\n`)
           console.log(`${test.message || ''}\n${COLORS.reset}`)
+        }
+        if (test.test_code) {
+          console.log(`Test code: ${test.test_code}\n`)
         }
       })
 

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ try {
     core.setFailed("Some tests failed.");
   }
 } catch (error) {
+  console.log(error.message)
   const input = core.getInput("runners");
   const pattern = /^([a-zA-Z0-9]+,)*[a-zA-Z0-9]+$/
   if (!pattern.test(input)) {

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,6 @@ try {
     core.setFailed("Some tests failed.");
   }
 } catch (error) {
-  console.log(error.message)
   const input = core.getInput("runners");
   const pattern = /^([a-zA-Z0-9]+,)*[a-zA-Z0-9]+$/
   if (!pattern.test(input)) {

--- a/test_sample.py
+++ b/test_sample.py
@@ -5,3 +5,7 @@ def sample_from_collection(collection):
 def test_sample():
     collection = [1, 2, 3, 4, 5]
     assert sample_from_collection(collection) in collection
+
+def test_sample_poorly():
+    collection = [1, 2, 3, 4, 5]
+    assert sample_from_collection(collection) in [6]

--- a/test_sample.py
+++ b/test_sample.py
@@ -5,7 +5,3 @@ def sample_from_collection(collection):
 def test_sample():
     collection = [1, 2, 3, 4, 5]
     assert sample_from_collection(collection) in collection
-
-def test_sample_poorly():
-    collection = [1, 2, 3, 4, 5]
-    assert sample_from_collection(collection) in [6]


### PR DESCRIPTION
Changes to `.github/workflows/integration.yml`:

* Reduced the `max-score` from 100 to 10 for a the io-grader test
* Reduced the `max-score` from 100 to 20 for the commandd-graer test and added a new Python test with a `max-score` of 30 in the `jobs:` section. Also added the results of the Python test to the `Autograding Reporter` and included `python-test` in the `runners:` list.

Changes to `src/console-results.js`:

* Modified the console output for passed tests to include the line number if it's not 0. Similar changes were made for failed tests. Also added console output for the test code if it's available.

Changes to `test_sample.py`:

* Removed the `test_sample_poorly` function which was testing whether the sample from a collection is in a different collection. We no longer want a failing test in our integration test 😄 

See the latest run here: https://github.com/education/autograding-grading-reporter/actions/runs/8102301614/job/22144461093?pr=27